### PR TITLE
Make theme compatible with hugo 0.57+.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,7 +2,7 @@
 
 <body>
 <textarea id="source">
-{{ range .Data.Pages.ByWeight }}{{ if eq .Type "slide" }}{{ if eq .Params.contentType "md" }}{{ .RawContent }}{{ end }}{{ if eq .Params.contentType "sc" }}{{ .Content }}{{ end }}{{ end }}{{ end }}
+{{ range .Site.Pages.ByWeight }}{{ if eq .Type "slide" }}{{ if eq .Params.contentType "md" }}{{ .RawContent }}{{ end }}{{ if eq .Params.contentType "sc" }}{{ .Content }}{{ end }}{{ end }}{{ end }}
 </textarea>
 
 {{ partial "js" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,7 +6,7 @@
   <title>{{ if .IsHome }}{{ .Title }}{{ else }}{{ .Site.Title }}{{ end }}</title>
   <meta name="author" content="{{ with .Site.Params.name }}{{ . }}{{ end }}">
   <meta name="description" content="{{ with .Site.Params.description }}{{ . }}{{ end }}">
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
 
   {{ range .Site.Params.custom_css }}
   <link rel="stylesheet" href="{{ "/css/" | relURL }}{{ . }}">


### PR DESCRIPTION
This PR contains changes to make the theme work again with Hugo versions beyond 0.57. Without these changes, we end up with a blank page containing only one slide.